### PR TITLE
Call `process.exit()` if Unable to decrypt file

### DIFF
--- a/examples/autoPurchaseTickets/autoPurchaseTicket.js
+++ b/examples/autoPurchaseTickets/autoPurchaseTicket.js
@@ -96,6 +96,7 @@ try {
   );
 } catch (e) {
   console.log("Unable to decrypt file", e);
+  process.exit();
 }
 
 console.log("ALL GOOD WITH PASSWORD AND KEYSTORE");


### PR DESCRIPTION
You should halt process, because this is very strange case when keystore wasn't decrypted and process continue with message
```
ALL GOOD WITH PASSWORD AND KEYSTORE
```
