### PR TITLE
Add buildSendTimeLockTx method to web3FustionExtend

### DIFF
--- a/lib/web3FusionExtend.js
+++ b/lib/web3FusionExtend.js
@@ -373,6 +373,15 @@ exports.extend = function(web3) {
           null,
           web3._extend.formatters.inputDefaultBlockNumberFormatter
         ]
+      }),
+      new web3._extend.Method({
+        name: 'buildSendTimeLockTx',
+        call: 'fsn_buildSendTimeLockTx',
+        params: 2,
+        inputFormatter: [
+          null,
+          web3._extend.formatters.inputDefaultBlockNumberFormatter
+        ]
       })
     ]
   });
@@ -643,7 +652,7 @@ exports.extend = function(web3) {
             return web3._extend.formatters.inputTransactionFormatter(options);
           }
         ]
-      })
+      }),
     ]
   });
 


### PR DESCRIPTION
## Description

Please include a summary of the change.

This adds the buildSendTimeLockTx method call to the extension.
## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` with success and extended the tests if necessary. - the tests were broken in the master branch
- [ ] I ran ```npm run build``` and tested the resulting file from ```dist``` folder in a browser.
- [ ] I have tested my code on the live network.
